### PR TITLE
fix: deploy k0s airgap bundle to worker nodes

### DIFF
--- a/modules/k0s/systemd.nix
+++ b/modules/k0s/systemd.nix
@@ -38,7 +38,7 @@
         else ""
       }'';
   k0sBundle =
-    if (cfg.mode == "controller" || !cfg.airgap)
+    if (!cfg.airgap)
     then []
     else [pkgs."k0s_bundle${k0sVersionSuffix}"];
   bundles = k0sBundle ++ cfg.bundles;


### PR DESCRIPTION
k0s airgap bundle contains images like pause which are needed for worker nodes to run pods